### PR TITLE
Accept an extraOptions parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var path = require('path');
 var instrumenter = new istanbul.Instrumenter();
 var defaultIgnore = ['**/node_modules/**', '**/test/**', '**/tests/**'];
 
-module.exports = function(options) {
+module.exports = function(options, extraOptions) {
   options = options || {};
   
   function transform(file) {
@@ -30,7 +30,7 @@ module.exports = function(options) {
       
   if (typeof options === 'string') {
     var file = options;
-    options = {};
+    options = extraOptions || {};
     return transform(file);
   }
   


### PR DESCRIPTION
With this simple change we can now use the following configuration in package.json or karma.config:

``` javascript
browserify: {
     transform: [
             [{
                 ignore: ['**/bower_components/**', '**/*/*test.js']
             }, 'browserify-istanbul']
    ]
}
```
