### PR TITLE
add instrumenter option parse

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,14 +8,15 @@ var defaultIgnore = ['**/node_modules/**', '**/test/**', '**/tests/**'];
 
 module.exports = function(options, extraOptions) {
   options = options || {};
-  
+
   function transform(file) {
     var ignore = options.defaultIgnore === false ? [] : defaultIgnore;
     ignore = ignore.concat(options.ignore || []);
-    
+    instrumenter = options.instrumenter !== undefined ? options.instrumenter : new istanbul.Instrumenter();
+
     if (ignore.some(minimatch.bind(null, file)))
       return through();
-    
+
     var data = '';
     return through(function(buf) {
       data += buf;
@@ -31,12 +32,12 @@ module.exports = function(options, extraOptions) {
       });
     });
   }
-      
+
   if (typeof options === 'string') {
     var file = options;
     options = extraOptions || {};
     return transform(file);
   }
-  
+
   return transform;
 };


### PR DESCRIPTION
Based on issue https://github.com/devongovett/browserify-istanbul/issues/7 I add the possibility to give a specific istanbul instrument for browserify-istanbul.

