### PR TITLE
added instrument class option so this works with isparta

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,17 +1,16 @@
 var istanbul = require('istanbul');
 var through = require('through');
 var minimatch = require('minimatch');
-var path = require('path');
 
 var defaultIgnore = ['**/node_modules/**', '**/test/**', '**/tests/**', '**/*.json'];
 
 module.exports = function(options, extraOptions) {
   options = options || {};
-  
+
   function transform(file) {
     var ignore = options.defaultIgnore === false ? [] : defaultIgnore;
     ignore = ignore.concat(options.ignore || []);
-    
+
     if (ignore.some(minimatch.bind(null, file)))
       return through();
 
@@ -19,7 +18,7 @@ module.exports = function(options, extraOptions) {
     if (options.instrumenterConfig &&
         typeof options.instrumenterConfig === 'object')
       instrumenterConfig = options.instrumenterConfig;
-    var instrumenter = new istanbul.Instrumenter(instrumenterConfig);
+    var instrumenter = new (options.instrumenter || istanbul).Instrumenter(instrumenterConfig);
 
     var data = '';
     return through(function(buf) {
@@ -36,12 +35,12 @@ module.exports = function(options, extraOptions) {
       });
     });
   }
-      
+
   if (typeof options === 'string') {
     var file = options;
     options = extraOptions || {};
     return transform(file);
   }
-  
+
   return transform;
 };


### PR DESCRIPTION
This brings #8 up-to-date and uses @lukescott's suggestion to specify classes instead of instances. This works better with `options.instrumenterConfig`.