### PR TITLE
Dependency updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
   },
   "homepage": "https://github.com/devongovett/browserify-istanbul",
   "dependencies": {
-    "through": "^2.3.4",
+    "istanbul": "~0.3.6",
     "minimatch": "^0.2.14",
-    "istanbul": "^0.2.8"
+    "through": "^2.3.4"
   },
   "devDependencies": {
     "browserify": "^3.46.0",

--- a/package.json
+++ b/package.json
@@ -26,11 +26,11 @@
   "homepage": "https://github.com/devongovett/browserify-istanbul",
   "dependencies": {
     "istanbul": "~0.3.6",
-    "minimatch": "^0.2.14",
+    "minimatch": "^2.0.0",
     "through": "^2.3.4"
   },
   "devDependencies": {
-    "browserify": "^3.46.0",
-    "mocha": "^1.18.2"
+    "browserify": "^9.0.0",
+    "mocha": "^2.0.0"
   }
 }


### PR DESCRIPTION
Istanbul 0.3 is described as "Potentially backwards-incompatible" with 0.2 so this should be published as browserify-istanbul v0.2.0. 

Also, this closes #6 since https://github.com/gotwarlost/istanbul/pull/219 resolves https://github.com/gotwarlost/istanbul/issues/206.

cc @scamden