### PR TITLE
feat: upgrade to Istanbul 2.0 API, introduce nyc bin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 coverage/
 node_modules/
 .DS_Store
+.nyc_output

--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ browserifyBundle.transform(istanbul({
 ./node_modules/.bin/browserify -t [ browserify-istanbul --ignore "**/bower_components/**" ] test/test-*.js -o bundle.js
 ```
 
+### Interacting With Coverage Reports
+
+To load and manipulate coverage reports, the command line tool [nyc](https://www.npmjs.com/package/nyc) can be used:
+
+1. output the the `__coverage__` object to `./.nyc_output/coverage.json`.
+  * this can be facilitated using a library like [mocha-phantomjs-istanbul](https://www.npmjs.com/package/mocha-phantomjs-istanbul).
+2. execute nyc with a list of [reporters](https://github.com/istanbuljs/istanbul-reports/tree/master/lib).
+  * `nyc report --reporter=lcov --reporter=text-summary`.
+
+See [istanbul.js.org](https://istanbul.js.org/) for more examples and documentation.
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var through = require('through');
 var minimatch = require('minimatch');
+var objectAssign = require('object-assign');
 
 var defaultIgnore = ['**/node_modules/**', '**/bower_components/**', '**/test/**', '**/tests/**', '**/*.json'];
 
@@ -29,7 +30,16 @@ function transform(options, file) {
   if (shouldIgnoreFile(file, options))
     return through();
 
-  var instrumenter = new (options.instrumenter || require('istanbul')).Instrumenter(options.instrumenterConfig || {});
+  var instrumenterConfig = objectAssign({}, {
+    autoWrap: true,
+    coverageVariable: '__coverage__',
+    embedSource: true,
+    noCompact: false,
+    preserveComments: true,
+    produceSourceMap: true
+  }, options.instrumenterConfig);
+
+  var instrumenter = (options.instrumenter || require('istanbul-lib-instrument')).createInstrumenter(instrumenterConfig);
 
   var data = '';
   return through(function(buf) {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "lint": "eslint index.js test/*.js",
-    "test": "istanbul cover _mocha"
+    "pretest": "npm run lint",
+    "test": "nyc --reporter=text --reporter=lcov mocha"
   },
   "pre-commit": [
     "lint",
@@ -30,7 +31,9 @@
   },
   "homepage": "https://github.com/devongovett/browserify-istanbul",
   "dependencies": {
+    "istanbul-lib-instrument": "^1.3.0",
     "minimatch": "^3.0.0",
+    "object-assign": "^4.1.0",
     "through": "^2.3.8"
   },
   "devDependencies": {
@@ -38,8 +41,8 @@
     "coveralls": "^2.11.8",
     "eslint": "^2.2.0",
     "eslint-plugin-mocha": "^2.0.0",
-    "istanbul": "^0.4.2",
     "mocha": "^2.4.5",
+    "nyc": "^10.0.0",
     "pre-commit": "^1.1.2"
   }
 }


### PR DESCRIPTION
Upgrades to the Istanbul 2.0 API (addressing the issue discussed in https://github.com/istanbuljs/nyc/issues/373).

Pulls in the nyc CLI tool to the project itself, and documents the usage of the tool for folks using `browserify-istanbul`.

reviewers: @alexindigo (hey Alex!), @devongovettl, @alexjeffburke.

Note: this should probably be a _major version bump_, as Istanbul 2.0 has some slight variations with regards to how it instruments files.