### PR TITLE
Allow for stripping of base path for ignores

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,10 @@ var defaultIgnore = ['**/node_modules/**', '**/bower_components/**', '**/test/**
 function shouldIgnoreFile(file, options) {
   var ignore = options.defaultIgnore === false ? [] : defaultIgnore;
   ignore = ignore.concat(options.ignore || []);
+  var cwd = process.cwd();
+
+  if (options.stripBasePath)
+    file = file.replace(cwd, '');
 
   return ignore.some(function(pattern) {
     return minimatch(file, pattern, options.minimatchOptions);

--- a/test/index.js
+++ b/test/index.js
@@ -58,6 +58,25 @@ describe('browserify-istanbul', function() {
       });
   });
 
+  it('should allow stripping of leading paths off files', function(done) {
+    browserify(__dirname + '/../testdata/tests/file.js')
+      .transform(istanbul({ stripBasePath: true, ignore: ['**/browserify_istanbul/**'], defaultIgnore: false }))
+      .bundle(function(err, src) {
+        if (err)
+          return done(err);
+
+        var ctx = {};
+        vm.runInNewContext(src, ctx);
+
+        assert.equal(typeof ctx.__coverage__, 'object');
+        assert.equal(typeof ctx.__coverage__[require.resolve(__dirname + '/../testdata/src/file.js')], 'object');
+        assert.equal(typeof ctx.__coverage__[require.resolve(__dirname + '/../testdata/src/ignored.js')], 'object');
+        assert.equal(typeof ctx.__coverage__[require.resolve(__dirname + '/../testdata/browserify-istanbul/ignored.js')], 'undefined');
+        assert.equal(typeof ctx.__coverage__[require.resolve(__dirname + '/../testdata/tests/file.js')], 'object');
+        done();
+      });
+  });
+
   it('should handle invalid .js', function(done) {
     browserify(__dirname + '/../testdata/tests/invalid.js')
       .transform(istanbul())

--- a/testdata/browserify-istanbul/ignored.js
+++ b/testdata/browserify-istanbul/ignored.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+  return 'hey there!';
+};


### PR DESCRIPTION
This fixes an issue where browserify-istanbul won't run if one of your parent directories is named `node_modules`.  We want to ignore children directories name `node_modules` but not parent directories from the root directory in which we're running our tests.

This is required by our setup, as we're using the same development setup w/r/t to directories as the dat project: https://github.com/datproject/dat/blob/master/CONTRIBUTING.md#developing-inside-a-node_modules-folder