### PR TITLE
Update istanbul and other dependencies

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 node_js:
-  - "4"
-  - "6"
+  - "8"
+  - "10"
+  - "12"
   - "stable"
 script:
   - node --version

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var through = require('through');
+var through = require('through2');
 var minimatch = require('minimatch');
 var objectAssign = require('object-assign');
 
@@ -42,17 +42,19 @@ function transform(options, file) {
   var instrumenter = (options.instrumenter || require('istanbul-lib-instrument')).createInstrumenter(instrumenterConfig);
 
   var data = '';
-  return through(function(buf) {
+  return through(function(buf, enc, callback) {
     data += buf;
-  }, function() {
+    callback();
+  }, function(callback) {
     var self = this;
     instrumenter.instrument(data, file, function(err, code) {
       if (!err) {
-        self.queue(code);
+        self.push(code);
       } else {
         self.emit('error', err);
       }
-      self.queue(null);
+      self.push(null);
+      callback();
     });
   });
 }

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 var through = require('through2');
 var minimatch = require('minimatch');
-var objectAssign = require('object-assign');
 
 var defaultIgnore = ['**/node_modules/**', '**/bower_components/**', '**/test/**', '**/tests/**', '**/*.json'];
 
@@ -30,7 +29,7 @@ function transform(options, file) {
   if (shouldIgnoreFile(file, options))
     return through();
 
-  var instrumenterConfig = objectAssign({}, {
+  var instrumenterConfig = Object.assign({}, {
     autoWrap: true,
     coverageVariable: '__coverage__',
     embedSource: true,

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
   "devDependencies": {
     "browserify": "^16.5.0",
     "coveralls": "^3.0.0",
-    "eslint": "^4.8.0",
-    "eslint-plugin-mocha": "^4.11.0",
+    "eslint": "^6.8.0",
+    "eslint-plugin-mocha": "^6.2.2",
     "mocha": "^4.0.1",
     "nyc": "^15.0.0",
     "pre-commit": "^1.2.2"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "istanbul-lib-instrument": "^1.8.0",
     "minimatch": "^3.0.4",
     "object-assign": "^4.1.1",
-    "through": "^2.3.8"
+    "through2": "^3.0.1"
   },
   "devDependencies": {
     "browserify": "^14.4.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "through2": "^3.0.1"
   },
   "devDependencies": {
-    "browserify": "^14.4.0",
+    "browserify": "^16.5.0",
     "coveralls": "^3.0.0",
     "eslint": "^4.8.0",
     "eslint-plugin-mocha": "^4.11.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/devongovett/browserify-istanbul",
   "dependencies": {
-    "istanbul-lib-instrument": "^1.8.0",
+    "istanbul-lib-instrument": "^4.0.0",
     "minimatch": "^3.0.4",
     "object-assign": "^4.1.1",
     "through2": "^3.0.1"
@@ -42,7 +42,7 @@
     "eslint": "^4.8.0",
     "eslint-plugin-mocha": "^4.11.0",
     "mocha": "^4.0.1",
-    "nyc": "^11.2.1",
+    "nyc": "^15.0.0",
     "pre-commit": "^1.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "coveralls": "^3.0.0",
     "eslint": "^6.8.0",
     "eslint-plugin-mocha": "^6.2.2",
-    "mocha": "^4.0.1",
+    "mocha": "^7.0.0",
     "nyc": "^15.0.0",
     "pre-commit": "^1.2.2"
   }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   "dependencies": {
     "istanbul-lib-instrument": "^4.0.0",
     "minimatch": "^3.0.4",
-    "object-assign": "^4.1.1",
     "through2": "^3.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION

Upgrades istanbul, which dropped support for node.js versions < 8. Object.assign can then be used without a polyfill. While I was at it i upgraded all the other dependencies too. There don't seem to be any breaking changes that affect browserify-istanbul.

The latest istanbul version no longer has a transitive dependency on core-js, which saves several megs in installation size and solves a deprecation warning on install.

This requires a major version bump because of the minimum node.js requirement.

Thanks!